### PR TITLE
Fix parsing of MathTerm node.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -555,7 +555,7 @@ class Parser
                     break;
                 case '%':
                     $this->nextToken();
-                    $value = new OperationNode($value, $this->parseMathExpr(), OperationNode::MOD);
+                    $value = new OperationNode($value, $this->parseMathFactor(), OperationNode::MOD);
                     break;
                 case '/':
                     $this->nextToken();


### PR DESCRIPTION
According to the EBNF, the right-hand part of an "%" operator is a MathFactor, while it is parsing a MathExpr instead.